### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -64,26 +64,19 @@ $(function(){
   })
 
   var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     var last_message_id = $('.main-chat__messages__message:last').data("message-id");
     $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
       url: "api/messages",
-      //ルーティングで設定した通りhttpメソッドをgetに指定
       type: 'get',
       dataType: 'json',
-      //dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
     .done(function(messages) {
       if (messages.length !== 0) {
-        //追加するHTMLの入れ物を作る
         var insertHTML = '';
-        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
         $.each(messages, function(i, message) {
           insertHTML += buildHTML(message)
         });
-        //メッセージが入ったHTMLに、入れ物ごと追加
         $('.main-chat__messages').append(insertHTML)
         $('.main-chat__messages').animate({ scrollTop: $('.main-chat__messages')[0].scrollHeight});
       }

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){
+
   function buildHTML(message){
       if ( message.image ) {
         var html =
-        `<div class="main-chat__messages__message">
+        `<div class="main-chat__messages__message" data-message-id=${message.id}>
             <div class="main-chat__messages__message__about">
               <div class="main-chat__messages__message__about__user-name">
                 ${message.user_name}
@@ -21,7 +22,7 @@ $(function(){
         return html;
       } else {
         var html =
-        `<div class="main-chat__messages__message">
+        `<div class="main-chat__messages__message" data-message-id=${message.id}>
             <div class="main-chat__messages__message__about">
               <div class="main-chat__messages__message__about__user-name">
                 ${message.user_name}
@@ -61,4 +62,37 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     });
   })
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.main-chat__messages__message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.main-chat__messages').append(insertHTML)
+        $('.main-chat__messages').animate({ scrollTop: $('.main-chat__messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__messages__message
+.main-chat__messages__message{data: {message: {id: message.id}}}
   .main-chat__messages__message__about
     .main-chat__messages__message__about__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
## What
- あるブラウザでメッセージが送信された際に、その他のブラウザでリロードをせずにメッセージが表示されるようにする。

## Why
- 毎回リロードしないと他人のメッセージが見れないのは、チャットアプリとしてとても不便だから。

## 自動更新の画面(GIF)
https://gyazo.com/1782ea542c6c3f93e99694703f5aa99b